### PR TITLE
fix: default label styling missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "payload-label-popover",
-  "version": "1.0.2-beta.0",
+  "version": "1.0.2-beta.1",
   "description": "A plugin to add descriptive popovers to field labels in Payload.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/LabelPopover.tsx
+++ b/src/LabelPopover.tsx
@@ -19,7 +19,10 @@ export const LabelPopover: React.FC<Props> = props => {
 
   if (label) {
     return (
-      <div style={{ display: 'flex' }}>
+      <label
+        className="field-label"
+        style={{ display: 'flex', width: 'fit-content', maxWidth: '100%' }}
+      >
         {getTranslation(label, i18n)}
         {required && <span className="required">*</span>}
         {showLabelPopover && (
@@ -79,7 +82,7 @@ export const LabelPopover: React.FC<Props> = props => {
             </button>
           </Popover>
         )}
-      </div>
+      </label>
     )
   }
 


### PR DESCRIPTION
payloadcms default label styling missing (most noticeable on required fields)

before: 
![image](https://github.com/TMRRWinc/payload-label-popover/assets/41651465/422b6a99-e7de-448b-85ad-00f6b0ebb973)

after:
![image](https://github.com/TMRRWinc/payload-label-popover/assets/41651465/14d6a4c6-9470-4a31-ab86-5982d93e2053)
