### PR TITLE
fix: popover incorrectly located for fields rendered off screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tmrrw-labs/payload-plugin-label-popover",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A plugin to add descriptive popovers to field labels in Payload.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/LabelPopover.tsx
+++ b/src/LabelPopover.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { ArrowContainer, Popover } from 'react-tiny-popover'
+import { ArrowContainer, Popover, BoundaryViolations } from 'react-tiny-popover'
 
 import { getTranslation } from 'payload/utilities'
 
@@ -17,18 +17,22 @@ export const LabelPopover: React.FC<Props> = props => {
   const { t, i18n } = useTranslation()
   const [isPopoverOpen, setIsPopoverOpen] = useState(false)
 
+  const ref = useRef<HTMLLabelElement>(null)
   if (label) {
     return (
       <label
         className="field-label"
         style={{ display: 'flex', width: 'fit-content', maxWidth: '100%' }}
+        ref={ref}
       >
         {getTranslation(label, i18n)}
         {required && <span className="required">*</span>}
         {showLabelPopover && (
           <Popover
+            parentElement={ref.current || undefined} // This is not the correct usage of parentElement. But it is fixing the issue of the popover not positioning correctly for fields rendered off page
+            containerStyle={{ zIndex: '9999' }}
             isOpen={isPopoverOpen}
-            positions={['top', 'right', 'left', 'bottom']}
+            positions={['top', 'right', 'bottom', 'left']}
             padding={10}
             onClickOutside={() => setIsPopoverOpen(false)}
             content={({ position, childRect, popoverRect }) => (


### PR DESCRIPTION
fields off screen with a label popover would have their popover incorrectly positioned. 

This pr uses (incorrectly) the parentElement property of the Popover component to fix this issue.